### PR TITLE
Reduce final docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN wget https://service.pdok.nl/lv/bag/atom/downloads/lvbag-extract-nl.zip \
 
 FROM base as server
 WORKDIR /srv
-RUN apt purge -y wget wget build-essential cmake
-COPY --from=builder --chown=baguser:baguser /build/bagconv /build/bagserv .
+RUN chown baguser:baguser /srv && apt purge -y wget wget build-essential cmake
+COPY --from=builder --chown=baguser:baguser /build/bagconv /build/bagserv ./
 COPY --from=bagger --chown=baguser:baguser /bagger/bag.sqlite .
 USER baguser
 CMD ["/srv/bagserv", "1234"]

--- a/README.md
+++ b/README.md
@@ -220,12 +220,14 @@ active. Send it queries like
 
 # Docker
 Building the Docker image requires at least 120GB of free disk space 
-during build time and can take around 15 minutes to build. Please
-make sure you are using a [recent](https://docs.docker.com/desktop/install/linux-install/) 
+during build time and can take up to 15 minutes to build. The resulting
+`bag.sqlite` and docker image combined will be approximately 10GB in size.
+
+Please make sure you are using a [recent](https://docs.docker.com/desktop/install/linux-install/) 
 Docker engine version (for example 24.0.5 or newer).
 
 ```
-$ docker build -t bagconv:latest --compress .
+$ docker build -t bagconv:latest .
 $ docker run -p 1234:1234 bagconv:latest
 
 $ curl -s http://127.0.0.1:1234/7311KZ/110 | jq
@@ -249,13 +251,10 @@ $ curl -s http://127.0.0.1:1234/7311KZ/110 | jq
 ]
 ```
 
-To clean up build artifacts you can (after running `docker run bagconv:latest` at least once)
-run the following command. Warning: this will remove all cache and dangling images and 
-containers from your host. This should free up approximately 120GB of space on your machine.
+To clean up build artifacts you can (after running `docker run bagconv:latest` at least once) 
+run the following command. Warning: this will remove all cache and dangling images and containers 
+from your host. This should free up approximately 110GB of space on your machine.
 
 ```
-docker system prune -af
+docker system prune
 ```
-
-If you have any suggestions on how to further minimize the resulting Docker image size,
-feel free to contribute!


### PR DESCRIPTION
I've added some small improvements which result in a significantly smaller final docker image (10GB instead of 19GB).

The larger image was caused by the now removed `RUN chown` command. This command created a second layer with the same `bag.sqlite` file. Using `COPY --chown` mitigates this issue.