### PR TITLE
Added nlohmann-json3-dev dependency. Changed debian:latest to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:latest as base
+FROM debian:bookworm as base
 RUN useradd --system --create-home --home-dir /home/baguser --user-group --uid 1000 --shell /bin/bash baguser
-RUN apt update && apt install -y build-essential cmake sqlite3 libsqlite3-dev zlib1g-dev wget unzip
+RUN apt update && apt install -y build-essential cmake sqlite3 libsqlite3-dev zlib1g-dev wget unzip nlohmann-json3-dev
 
 FROM base as builder
 WORKDIR /build


### PR DESCRIPTION
bagconv won't compile without it on debian bookworm (which is the current latest). Also changed the debian version to bookworm to ensure that the build won't break in later debian versions.