### PR TITLE
Make the imports match the importdir in the CMake configuration

### DIFF
--- a/jsonhelper.cc
+++ b/jsonhelper.cc
@@ -1,5 +1,5 @@
 #include "sqlwriter.hh"
-#include "nlohmann/json.hpp"
+#include "json.hpp"
 
 using namespace std;
 

--- a/jsonhelper.hh
+++ b/jsonhelper.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "sqlwriter.hh"
-#include "nlohmann/json.hpp"
+#include "json.hpp"
 
 // turn results from SQLiteWriter into JSON
 nlohmann::json packResultsJson(const std::vector<std::unordered_map<std::string, MiniSQLite::outvar_t>>& result, bool fillnull=true);


### PR DESCRIPTION
In `CMakeLists.txt`, the include directory ` ext/nlohmann` is added. However in `jsonhelper.[cc|hh]`, the import tries to import `nlohmann/json.hpp`. This leads to an error when making the code.

So I removed the nlohmann dir from the imports because I think this is consistent with other imports :) 